### PR TITLE
Changed hyphen to underscore in chef variable names

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@
 driver:
   name: vagrant
   network:
-    - ["private_network", {ip: "192.168.35.35"}]
+    - ["private_network", {ip: "192.168.35.36"}]
 
 provisioner:
   name: chef_zero

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,7 +22,7 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[nexus-repository-manager::default]
+      - recipe[nexus_repository_manager::default]
     verifier:
       inspec_tests:
         - test/smoke/default

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,5 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,5 +1,5 @@
 DEPENDENCIES
-  nexus-repository-manager
+  nexus_repository_manager
     path: .
     metadata: true
 
@@ -11,7 +11,7 @@ GRAPH
     homebrew (>= 0.0.0)
     windows (>= 0.0.0)
   limits (1.0.0)
-  nexus-repository-manager (0.1.0)
+  nexus_repository_manager (0.1.0)
     java (~> 1.50)
     limits (~> 1.0.0)
     tar (~> 2.1)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
@@ -11,15 +11,15 @@ default['java']['oracle']['accept_oracle_download_terms'] = true
 # This prevents the java recipe from configuring java alternatives
 default['java']['jdk']['8']['bin_cmds'] = [];
 
-default['nexus-repository-manager']['version'] = '3.6.0-02'
-default['nexus-repository-manager']['nexus_download_url'] = "https://download.sonatype.com/nexus/3/nexus-#{node['nexus-repository-manager']['version']}-unix.tar.gz"
-default['nexus-repository-manager']['checksum'] = '40b95b097b43cc8941a9700d24baf25ef94867286e43eaffa37cf188726bb2a7'
-default['nexus-repository-manager']['sonatype']['path'] = '/opt/sonatype'
-default['nexus-repository-manager']['sonatype']['sonatype_work']['path'] = default['nexus-repository-manager']['sonatype']['path'] + '/sonatype-work'
-default['nexus-repository-manager']['sonatype']['sonatype_work']['nexus3']['path'] = default['nexus-repository-manager']['sonatype']['sonatype_work']['path'] + '/nexus3'
-default['nexus-repository-manager']['nexus']['home']['path'] = default['nexus-repository-manager']['sonatype']['path'] + '/nexus'
-default['nexus-repository-manager']['nexus']['home']['bin']['path'] = default['nexus-repository-manager']['nexus']['home']['path'] + '/bin'
-default['nexus-repository-manager']['nexus']['data']['path'] = '/nexus-data'
-default['nexus-repository-manager']['nexus']['data']['etc']['path'] = default['nexus-repository-manager']['nexus']['data']['path'] + '/etc'
-default['nexus-repository-manager']['nexus']['data']['log']['path'] = default['nexus-repository-manager']['nexus']['data']['path'] + '/log'
-default['nexus-repository-manager']['nexus']['data']['tmp']['path'] = default['nexus-repository-manager']['nexus']['data']['path'] + '/tmp'
+default['nexus_repository_manager']['version'] = '3.6.0-02'
+default['nexus_repository_manager']['nexus_download_url'] = "https://download.sonatype.com/nexus/3/nexus-#{node['nexus_repository_manager']['version']}-unix.tar.gz"
+default['nexus_repository_manager']['checksum'] = '40b95b097b43cc8941a9700d24baf25ef94867286e43eaffa37cf188726bb2a7'
+default['nexus_repository_manager']['sonatype']['path'] = '/opt/sonatype'
+default['nexus_repository_manager']['sonatype']['sonatype_work']['path'] = default['nexus_repository_manager']['sonatype']['path'] + '/sonatype-work'
+default['nexus_repository_manager']['sonatype']['sonatype_work']['nexus3']['path'] = default['nexus_repository_manager']['sonatype']['sonatype_work']['path'] + '/nexus3'
+default['nexus_repository_manager']['nexus']['home']['path'] = default['nexus_repository_manager']['sonatype']['path'] + '/nexus'
+default['nexus_repository_manager']['nexus']['home']['bin']['path'] = default['nexus_repository_manager']['nexus']['home']['path'] + '/bin'
+default['nexus_repository_manager']['nexus']['data']['path'] = '/nexus-data'
+default['nexus_repository_manager']['nexus']['data']['etc']['path'] = default['nexus_repository_manager']['nexus']['data']['path'] + '/etc'
+default['nexus_repository_manager']['nexus']['data']['log']['path'] = default['nexus_repository_manager']['nexus']['data']['path'] + '/log'
+default['nexus_repository_manager']['nexus']['data']['tmp']['path'] = default['nexus_repository_manager']['nexus']['data']['path'] + '/tmp'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,9 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-name 'nexus-repository-manager'
+name 'nexus_repository_manager'
 maintainer 'Copyright (c) 2017-present Sonatype, Inc.'
 maintainer_email 'cloud-ops@sonatype.com'
 license 'Apache-2.0'
@@ -16,8 +16,8 @@ source_url 'https://github.com/sonatype/chef-nexus'
 supports 'ubuntu', '>= 16.04'
 supports 'centos', '>= 7.3'
 
-recipe 'nexus-repository-manager::default', 'Installs Nexus Repository Manager and starts it as systemd service.'
-recipe 'nexus-repository-manager::docker', 'Installs Nexus Repository Manager. Instead of a systemd service start-nexus-repository-manager.sh is provided in install_dir.'
+recipe 'nexus_repository_manager::default', 'Installs Nexus Repository Manager and starts it as systemd service.'
+recipe 'nexus_repository_manager::docker', 'Installs Nexus Repository Manager. Instead of a systemd service start_nexus_repository_manager.sh is provided in SONATYPE_DIR.'
 
 depends 'java', '~> 1.50'
 depends 'tar', '~> 2.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ supports 'ubuntu', '>= 16.04'
 supports 'centos', '>= 7.3'
 
 recipe 'nexus_repository_manager::default', 'Installs Nexus Repository Manager and starts it as systemd service.'
-recipe 'nexus_repository_manager::docker', 'Installs Nexus Repository Manager. Instead of a systemd service start_nexus_repository_manager.sh is provided in SONATYPE_DIR.'
+recipe 'nexus_repository_manager::docker', 'Installs Nexus Repository Manager. Instead of a systemd service start-nexus-repository-manager.sh is provided in SONATYPE_DIR.'
 
 depends 'java', '~> 1.50'
 depends 'tar', '~> 2.1'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -4,10 +4,10 @@
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-start_script = node['nexus_repository_manager']['sonatype']['path'] + '/start_nexus_repository_manager.sh'
+start_script = node['nexus_repository_manager']['sonatype']['path'] + '/start-nexus-repository-manager.sh'
 
 template start_script do
-  source 'start_nexus_repository_manager.sh.erb'
+  source 'start-nexus-repository-manager.sh.erb'
   owner 'root'
   group 'root'
   mode '0755'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,13 +1,13 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 # Recipe:: configure
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-start_script = node['nexus-repository-manager']['sonatype']['path'] + '/start-nexus-repository-manager.sh'
+start_script = node['nexus_repository_manager']['sonatype']['path'] + '/start_nexus_repository_manager.sh'
 
 template start_script do
-  source 'start-nexus-repository-manager.sh.erb'
+  source 'start_nexus_repository_manager.sh.erb'
   owner 'root'
   group 'root'
   mode '0755'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 # Recipe:: default
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
 include_recipe 'java'
-include_recipe 'nexus-repository-manager::download'
-include_recipe 'nexus-repository-manager::configure'
-include_recipe 'nexus-repository-manager::systemd'
+include_recipe 'nexus_repository_manager::download'
+include_recipe 'nexus_repository_manager::configure'
+include_recipe 'nexus_repository_manager::systemd'

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -1,12 +1,12 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 # Recipe:: docker
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
 include_recipe 'java'
-include_recipe 'nexus-repository-manager::download'
-include_recipe 'nexus-repository-manager::configure'
+include_recipe 'nexus_repository_manager::download'
+include_recipe 'nexus_repository_manager::configure'
 
 set_limit 'nexus' do
   type 'hard'

--- a/recipes/download.rb
+++ b/recipes/download.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 # Recipe:: download
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
@@ -9,7 +9,7 @@ user 'nexus' do
   comment 'Nexus Repository Manager user'
   system true
   shell '/bin/false'
-  home node['nexus-repository-manager']['nexus']['home']['path']
+  home node['nexus_repository_manager']['nexus']['home']['path']
   action :create
 end
 
@@ -18,7 +18,7 @@ group 'nexus' do
   action :create
 end
 
-directory node['nexus-repository-manager']['sonatype']['path'] do
+directory node['nexus_repository_manager']['sonatype']['path'] do
   owner 'root'
   group 'root'
   mode '755'
@@ -26,7 +26,7 @@ directory node['nexus-repository-manager']['sonatype']['path'] do
   action :create
 end
 
-directory node['nexus-repository-manager']['nexus']['home']['path'] do
+directory node['nexus_repository_manager']['nexus']['home']['path'] do
   owner 'root'
   group 'root'
   mode '755'
@@ -34,20 +34,20 @@ directory node['nexus-repository-manager']['nexus']['home']['path'] do
   action :create
 end
 
-tar_extract node['nexus-repository-manager']['nexus_download_url'] do
-  target_dir node['nexus-repository-manager']['nexus']['home']['path']
-  checksum node['nexus-repository-manager']['checksum']
-  creates node['nexus-repository-manager']['nexus']['home']['bin']['path']
+tar_extract node['nexus_repository_manager']['nexus_download_url'] do
+  target_dir node['nexus_repository_manager']['nexus']['home']['path']
+  checksum node['nexus_repository_manager']['checksum']
+  creates node['nexus_repository_manager']['nexus']['home']['bin']['path']
   tar_flags [ '-P', '--strip-components 1' ]
 end
 
 # Delete the nexus3 folder that is not used.
-directory node['nexus-repository-manager']['nexus']['home']['path'] + '/nexus3' do
+directory node['nexus_repository_manager']['nexus']['home']['path'] + '/nexus3' do
   recursive true
   action :delete
 end
 
-directory node['nexus-repository-manager']['nexus']['data']['path'] do
+directory node['nexus_repository_manager']['nexus']['data']['path'] do
   owner 'nexus'
   group 'nexus'
   mode '755'
@@ -55,7 +55,7 @@ directory node['nexus-repository-manager']['nexus']['data']['path'] do
   action :create
 end
 
-directory node['nexus-repository-manager']['nexus']['data']['etc']['path'] do
+directory node['nexus_repository_manager']['nexus']['data']['etc']['path'] do
   owner 'nexus'
   group 'nexus'
   mode '755'
@@ -63,7 +63,7 @@ directory node['nexus-repository-manager']['nexus']['data']['etc']['path'] do
   action :create
 end
 
-directory node['nexus-repository-manager']['nexus']['data']['log']['path'] do
+directory node['nexus_repository_manager']['nexus']['data']['log']['path'] do
   owner 'nexus'
   group 'nexus'
   mode '755'
@@ -71,7 +71,7 @@ directory node['nexus-repository-manager']['nexus']['data']['log']['path'] do
   action :create
 end
 
-directory node['nexus-repository-manager']['nexus']['data']['tmp']['path'] do
+directory node['nexus_repository_manager']['nexus']['data']['tmp']['path'] do
   owner 'nexus'
   group 'nexus'
   mode '755'
@@ -79,7 +79,7 @@ directory node['nexus-repository-manager']['nexus']['data']['tmp']['path'] do
   action :create
 end
 
-directory node['nexus-repository-manager']['sonatype']['sonatype_work']['path'] do
+directory node['nexus_repository_manager']['sonatype']['sonatype_work']['path'] do
   owner 'root'
   group 'root'
   mode '755'
@@ -87,8 +87,8 @@ directory node['nexus-repository-manager']['sonatype']['sonatype_work']['path'] 
   action :create
 end
 
-link node['nexus-repository-manager']['sonatype']['sonatype_work']['nexus3']['path'] do
-  to node['nexus-repository-manager']['nexus']['data']['path']
+link node['nexus_repository_manager']['sonatype']['sonatype_work']['nexus3']['path'] do
+  to node['nexus_repository_manager']['nexus']['data']['path']
   owner 'root'
   group 'root'
 end

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -4,7 +4,7 @@
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-systemd_unit 'nexus_repository_manager.service' do
+systemd_unit 'nexus-repository-manager.service' do
   content <<-EOU.gsub(/^\s+/, '')
   [Unit]
   Description=Nexus Repository Manager service
@@ -12,7 +12,7 @@ systemd_unit 'nexus_repository_manager.service' do
   [Service]
   Type=simple
   LimitNOFILE=65536
-  ExecStart=#{ node['nexus_repository_manager']['sonatype']['path'] }/start_nexus_repository_manager.sh
+  ExecStart=#{ node['nexus_repository_manager']['sonatype']['path'] }/start-nexus-repository-manager.sh
   User=nexus
   Restart=on-abort
   [Install]

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 # Recipe:: systemd
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-systemd_unit 'nexus-repository-manager.service' do
+systemd_unit 'nexus_repository_manager.service' do
   content <<-EOU.gsub(/^\s+/, '')
   [Unit]
   Description=Nexus Repository Manager service
@@ -12,7 +12,7 @@ systemd_unit 'nexus-repository-manager.service' do
   [Service]
   Type=simple
   LimitNOFILE=65536
-  ExecStart=#{ node['nexus-repository-manager']['sonatype']['path'] }/start-nexus-repository-manager.sh
+  ExecStart=#{ node['nexus_repository_manager']['sonatype']['path'] }/start_nexus_repository_manager.sh
   User=nexus
   Restart=on-abort
   [Install]

--- a/templates/start-nexus-repository-manager.sh.erb
+++ b/templates/start-nexus-repository-manager.sh.erb
@@ -3,5 +3,5 @@
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 #
 
-cd <%= node['nexus-repository-manager']['nexus']['home']['path'] %>
+cd <%= node['nexus_repository_manager']['nexus']['home']['path'] %>
 exec ./bin/nexus run

--- a/templates/start_nexus_repository_manager.sh.erb
+++ b/templates/start_nexus_repository_manager.sh.erb
@@ -1,7 +1,0 @@
-#!/bin/bash
-#
-# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
-#
-
-cd <%= node['nexus_repository_manager']['nexus']['home']['path'] %>
-exec ./bin/nexus run

--- a/templates/start_nexus_repository_manager.sh.erb
+++ b/templates/start_nexus_repository_manager.sh.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
+#
+
+cd <%= node['nexus_repository_manager']['nexus']['home']['path'] %>
+exec ./bin/nexus run

--- a/test/smoke/default/download_test.rb
+++ b/test/smoke/default/download_test.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 #
 
-# Inspec test for recipe nexus-repository-manager::download
+# Inspec test for recipe nexus_repository_manager::download
 
 describe user('nexus') do
   it { should exist }

--- a/test/smoke/default/systemd_test.rb
+++ b/test/smoke/default/systemd_test.rb
@@ -1,12 +1,12 @@
 #
-# Cookbook:: nexus-repository-manager
+# Cookbook:: nexus_repository_manager
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 #
 
-# Inspec test for recipe nexus-repository-manager::systemd
+# Inspec test for recipe nexus_repository_manager::systemd
 
-describe service 'nexus-repository-manager' do
+describe service 'nexus_repository_manager' do
   it { should be_enabled }
   it { should be_running }
 end

--- a/test/smoke/default/systemd_test.rb
+++ b/test/smoke/default/systemd_test.rb
@@ -6,7 +6,7 @@
 
 # Inspec test for recipe nexus_repository_manager::systemd
 
-describe service 'nexus_repository_manager' do
+describe service 'nexus-repository-manager' do
   it { should be_enabled }
   it { should be_running }
 end


### PR DESCRIPTION
For more consistent naming, use underscores instead of hyphens in chef related variable names.