### PR TITLE
INT-reduce-flakyness

### DIFF
--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -14,7 +14,9 @@ systemd_unit 'nexus-repository-manager.service' do
   LimitNOFILE=65536
   ExecStart=#{ node['nexus_repository_manager']['sonatype']['path'] }/start-nexus-repository-manager.sh
   User=nexus
-  Restart=on-abort
+  Restart=on-failure
+  StartLimitInterval=30min
+  StartLimitBurst=2
   [Install]
   WantedBy=multi-user.target
   EOU


### PR DESCRIPTION
JIRA: improvement
Jenkins: https://jenkins.zion.aws.s/job/integrations/job/nexus-ha-reference-feature/job/INT-mark-tests-flaky/

minor tweak to attempt to allow systemd to restart nexus if it fails (max twice within 30min) otherwise fail the service. 