### PR TITLE
chown while startup

### DIFF
--- a/templates/start-nexus-repository-manager.sh.erb
+++ b/templates/start-nexus-repository-manager.sh.erb
@@ -3,5 +3,7 @@
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 #
 
+chown -R nexus /nexus-data
+
 cd <%= node['nexus_repository_manager']['nexus_home']['path'] %>
 exec ./bin/nexus run


### PR DESCRIPTION
I am having issues with the official nexus3 docker image.

The nexus user gets a permission denied if i override the /nexus-data dir with a pvc in kubernetes.
a possbile fix would be changing the mode on the /nexus-data on container startup. Since you don't have a entrypoint.sh, i would suggest fixing it in the nexus startup script here.

You can have a look at this repo, and the solution for this problem his way.
https://github.com/cavemandaveman/nexus/blob/master/docker-entrypoint.sh

All the best,

Benjamin