### PR TITLE
fix(k8s): dropping nexus lock file based on environment

### DIFF
--- a/templates/start-nexus-repository-manager.sh.erb
+++ b/templates/start-nexus-repository-manager.sh.erb
@@ -4,4 +4,5 @@
 #
 
 cd <%= node['nexus_repository_manager']['nexus_home']['path'] %>
+test "$FORCE_DROP_NEXUS_LOCK" && rm -f <%= node['nexus_repository_manager']['nexus_data']['path'] %>/lock
 exec ./bin/nexus run


### PR DESCRIPTION
Running OpenShift (or Kubernetes derivatives), when a Nexus container
is not properly shut down, then Nexus lock file may still be present
on disk, starting a fresh container. Nexus would then refuse to start,
until said lock is manually removed.

I could be wrong, although I suppose we could use some environment
variable to automate that task.