### PR TITLE
INT-938 Update NXRM version regex to match the one from the docker-nexus3 Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ node('ubuntu-chef-zion') {
         OsTools.runSafe(this, "git checkout ${branch}")
         def defaultsFile = readFile(file: defaultsFileLocation)
 
-        def versionRegex = /(default\['nexus_repository_manager'\]\['version'\] = ')(\d\.\d\.\d\-\d{2})(')/
+        def versionRegex = /(default\['nexus_repository_manager'\]\['version'\] = ')(\d\.\d{1,3}\.\d\-\d{2})(')/
         def shaRegex = /(default\['nexus_repository_manager'\]\['nexus_download_sha256'\] = ')([A-Fa-f0-9]{64})(')/
 
         defaultsFile = defaultsFile.replaceAll(versionRegex, "\$1${params.nexus_rm_version}\$3")


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/INT-938
CI: https://jenkins.zion.aws.s/job/integrations/job/cloud/job/chef-nexus-repository-manager-feature/job/INT-938-fix-bad-version-regex/

Copied regex from: https://github.com/sonatype/docker-nexus3/blob/master/Jenkinsfile#L225