### PR TITLE
INT-1754 Pin the chef version used for the tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: "14.12.9"
   # You may wish to disable always updating cookbooks in CI or other testing environments.
   # For example:
   #   always_update_cookbooks: <%= !ENV['CI'] %>


### PR DESCRIPTION
The newer chef versions require that a license is accepted before it will continue. This pins the chef version to a release prior to this license acceptance change.